### PR TITLE
Enhanced simple go server: Programmed graceful shutdown of the server to stop occupying the port

### DIFF
--- a/top_dir/simple_go_server/README.md
+++ b/top_dir/simple_go_server/README.md
@@ -17,3 +17,8 @@ Procedure to run:
 2) go build
 3) go run main.go
 4) Allow firewall permissions if prompted, go to a browser and enter localhost:8080/
+
+Debugging:
+1) If you see Main page still on localhost:8080 after terminating server, then it might be due to 
+    a) Concurrency of the go routine triggering ListenAndServe() subroutine. Use "err != http.ErrServerClosed" when triggering it. Or replace "log.Fatal(err)" with some printf
+    b) OS waiting for TIME_WAIT (40-120 seconds) for transmission of residual packets. It is recommended to wait out the time. Else use "SO_REUSEADDR" (for development purpose only).

--- a/top_dir/simple_go_server/src/main.go
+++ b/top_dir/simple_go_server/src/main.go
@@ -51,13 +51,15 @@ func main() {
 
 	server := &http.Server{
 		Addr:    ":8080",
-		Handler: fileServer, // File server instead of ServeMux
+		Handler: nil, // nil here to handle all type of routes; Allows http.HandleFunc routes to work
 	}
-
-	fmt.Println("Starting server at port 8080...")
-	if err := server.ListenAndServe(); err != nil {
-		log.Fatal(err)
-	}
+	go func() {
+		fmt.Println("Starting server at port 8080...")
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server error: %v", err)
+		}
+		fmt.Println("Server closed")
+	}()
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
@@ -74,5 +76,4 @@ func main() {
 	} else {
 		fmt.Println("Server stopped gracefully.")
 	}
-
 }


### PR DESCRIPTION
Programmed graceful shutdown of the server to stop occupying the port by using go routine (leveraging concurrency) and handling the SIGTERM interrupt from OS